### PR TITLE
Fix audio and video stream

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@ This repo demonstrates how you can use Pion WebRTC to play H264 and Ogg from dis
 can be used to pull from other sources.
 
 ### You can use the follow command to create inputs
-* ffmpeg -i $INPUT_FILE -g 30  -preset fast -profile:v baseline -bsf h264_mp4toannexb output.h264
+* ffmpeg -i $INPUT_FILE -an -c:v libx264 -bsf:v h264_mp4toannexb -b:v 2M -max_delay 0 -bf 0 output.h264
 * ffmpeg -i $INPUT_FILE -c:a libopus -page_duration 20000 -vn output.ogg
 
 ### Or pull from my website


### PR DESCRIPTION
I've implemented the fix we talked about on Slack. Audio and video transmit flawlessly now.

Also, with the original FFmpeg command for creating H264 video, I had lag and desynchronization issues (video would fall behind the audio). I've created a new command with fixes those issues.

I think we should also apply these fixes to the official examples in the pion/webrtc repo that use IVF, since they have the same issue. If you like, I can make a PR for that as well.

Also maybe the play-from-disk-h264 can be added to the official examples?

Only thing that remains is that the video stream takes a few seconds of loading to start. In my code, I fixed that by using code I found in one of pion/webrtc's issues which merges SPS and PPS packets:
```go
// ** Fixes to make video start streaming instantly **
// 1. Prepend NAL start prefix code
nal.Data = append([]byte{0x00, 0x00, 0x00, 0x01}, nal.Data...)
// 2. Merge SPS and PPS packets
if nal.UnitType == h264reader.NalUnitTypeSPS || nal.UnitType == h264reader.NalUnitTypePPS {
    spsAndPpsCache = append(spsAndPpsCache, nal.Data...)
    continue
} else if nal.UnitType == h264reader.NalUnitTypeCodedSliceIdr {
    nal.Data = append(spsAndPpsCache, nal.Data...)
    spsAndPpsCache = []byte{}
}
```
However, I was unsure if this should be added to this example, because this looks like a separate fix to the H264 packetizer.

